### PR TITLE
Optimise ModelLoaderMixin

### DIFF
--- a/src/main/java/dev/lambdaurora/aurorasdeco/mixin/client/ModelLoaderMixin.java
+++ b/src/main/java/dev/lambdaurora/aurorasdeco/mixin/client/ModelLoaderMixin.java
@@ -37,7 +37,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.Map;
 
@@ -66,7 +66,7 @@ public abstract class ModelLoaderMixin {
 	@Unique
 	private final RestModelManager aurorasdeco$restModelManager = new RestModelManager((ModelLoader) (Object) this);
 	@Unique
-	private final Set<Identifier> aurorasdeco$visitedModels = new LinkedHashSet<>();
+	private final Set<Identifier> aurorasdeco$visitedModels = new HashSet<>();
 
 	@Shadow
 	protected abstract void putModel(Identifier id, UnbakedModel unbakedModel);

--- a/src/main/java/dev/lambdaurora/aurorasdeco/mixin/client/ModelLoaderMixin.java
+++ b/src/main/java/dev/lambdaurora/aurorasdeco/mixin/client/ModelLoaderMixin.java
@@ -37,8 +37,8 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import java.util.Map;
 
 /**
@@ -66,7 +66,7 @@ public abstract class ModelLoaderMixin {
 	@Unique
 	private final RestModelManager aurorasdeco$restModelManager = new RestModelManager((ModelLoader) (Object) this);
 	@Unique
-	private final List<Identifier> aurorasdeco$visitedModels = new ArrayList<>();
+	private final Set<Identifier> aurorasdeco$visitedModels = new LinkedHashSet<>();
 
 	@Shadow
 	protected abstract void putModel(Identifier id, UnbakedModel unbakedModel);


### PR DESCRIPTION
By replacing List.contains with Set.contains.

I encountered this by testing @SplendidAlakey s pack <https://github.com/SplendidAlakey/Perfectly-Splendid>, and I noticed that 12s of loading time is spent in `ArrayList.contains` in this method - so this PR *should* speed that up?

(Draft because I haven't tested this yet)